### PR TITLE
Bugfix: newWindow is null

### DIFF
--- a/sharer.js
+++ b/sharer.js
@@ -258,8 +258,10 @@ Sharer.prototype = {
                 popParams = 'scrollbars=no, width=' + popWidth + ', height=' + popHeight + ', top=' + top + ', left=' + left,
                 newWindow = window.open(sharer.shareUrl, '', popParams);
 
-            if (window.focus) {
+            if (newWindow && typeof newWindow.focus === 'function') {
                 newWindow.focus();
+            } else {
+                window.location.href = sharer.shareUrl;
             }
         } else {
             window.location.href = sharer.shareUrl;


### PR DESCRIPTION
Hey there! Looks like newWindow can sometimes be null if browser blocks the popup ([StackOverflow](https://stackoverflow.com/questions/18401331/window-open-returns-null-and-fails-in-inline-script-but-works-from-console), [MSDN](https://social.msdn.microsoft.com/Forums/ie/en-US/84d40cb4-f7fb-4314-a0ef-c0bf21d5fed5/windowopen-returns-null?forum=iewebdevelopment), [error report](https://sentry.io/share/issue/1621d7b35b2f47bba3eef7fe8885d746)). That results in a TypeError when the library attempts to bring the window into focus. I modified the if clause to check that and added a fallback to open the link in the same window if popup fails to open.